### PR TITLE
Fixed AGP 4.2<= compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'fman.ge.smart_auth'
+    }
+    
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
## Description

- Added `namespace` field, required in later Gradle and AGP versions.
- Fixes #7 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
