### PR TITLE
Fix build android build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'fman.ge.smart_auth'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '1.9.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.0'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/src/main/kotlin/fman/ge/smart_auth/AppSignatueHelper.kt
+++ b/android/src/main/kotlin/fman/ge/smart_auth/AppSignatueHelper.kt
@@ -31,7 +31,7 @@ class AppSignatureHelper(context: Context) : ContextWrapper(context) {
             val packageName = packageName
             val packageManager = packageManager
 
-            val signatures: Array<Signature> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val signatures: Array<Signature>? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 packageManager.getPackageInfo(
                     packageName,
                     PackageManager.GET_SIGNING_CERTIFICATES
@@ -41,8 +41,8 @@ class AppSignatureHelper(context: Context) : ContextWrapper(context) {
             }
 
             signatures
-                .mapNotNull { hash(packageName, it.toCharsString()) }
-                .mapTo(appCodes) { it }
+                ?.mapNotNull { hash(packageName, it.toCharsString()) }
+                ?.mapTo(appCodes) { it }
             return appCodes
         } catch (e: PackageManager.NameNotFoundException) {
             Log.e(TAG, "Unable to find package to obtain hash.", e)

--- a/android/src/main/kotlin/fman/ge/smart_auth/AppSignatueHelper.kt
+++ b/android/src/main/kotlin/fman/ge/smart_auth/AppSignatueHelper.kt
@@ -35,7 +35,7 @@ class AppSignatureHelper(context: Context) : ContextWrapper(context) {
                 packageManager.getPackageInfo(
                     packageName,
                     PackageManager.GET_SIGNING_CERTIFICATES
-                ).signingInfo.apkContentsSigners
+                ).signingInfo?.apkContentsSigners
             } else {
                 packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNATURES).signatures
             }


### PR DESCRIPTION
<!--
  Fix building process for android. 

`Note: Recompile with -Xlint:unchecked for details.
pub.dev/smart_auth-2.0.0/android/src/main/kotlin/fman/ge/smart_auth/AppSignatueHelper.kt:38:30 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type SigningInfo?
pub.dev/smart_auth-2.0.0/android/src/main/kotlin/fman/ge/smart_auth/AppSignatueHelper.kt:39:20 Type mismatch: inferred type is Array<(out) Signature!>? but Array was expected

FAILURE: Build failed with an exception.`
-->

## Description

Change variable type from Array<Signature> to Array<Signature>? and handling **signature** variable after init

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
